### PR TITLE
git install requires binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo install captain
 ### From source
 
 ```bash
-cargo install --git https://github.com/bearcove/captain
+cargo install --git https://github.com/bearcove/captain captain
 ```
 
 ## Quick Start


### PR DESCRIPTION
Fixes "error: multiple packages with binaries found: captain, xtask. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify a package, e.g. `cargo install --git https://github.com/bearcove/captain captain`."